### PR TITLE
Improve header of Projects Page

### DIFF
--- a/louis_venhoff_portfolio/src/App.tsx
+++ b/louis_venhoff_portfolio/src/App.tsx
@@ -16,7 +16,7 @@ function App() {
       <>
         <Header>
           <NavButton title="Home" target={'home'} />
-          <NavButton title="Projekte" target={'construction'} />
+          <NavButton title="Projekte" target={'projects'} />
           <NavButton title="Über mich" target={'construction'} />
         </Header>
         <Outlet />

--- a/louis_venhoff_portfolio/src/components/contentHeader/contentHeader.tsx
+++ b/louis_venhoff_portfolio/src/components/contentHeader/contentHeader.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import "../../styles/components/contentHeader.css";
+import { Button, IconButton } from "@chakra-ui/react";
+import { HiChevronLeft } from "react-icons/hi";
 
 type ContentHeaderProps = {
     children: React.ReactNode;
@@ -9,7 +11,13 @@ type ContentHeaderProps = {
 const ContentHeader:React.FC<ContentHeaderProps> = ({children}: ContentHeaderProps) => {
     return(
         <div className="content-header--main">
-            {children}
+            <div className="flex items-start">
+                <IconButton size="xl" backgroundColor="#242424">
+                    <HiChevronLeft />
+                </IconButton>
+                {children}
+            </div>
+            
         </div>
     );
 }

--- a/louis_venhoff_portfolio/src/components/contentHeader/contentHeader.tsx
+++ b/louis_venhoff_portfolio/src/components/contentHeader/contentHeader.tsx
@@ -1,20 +1,31 @@
-import React from "react";
+import React, { JSX } from "react";
 import "../../styles/components/contentHeader.css";
 import { Button, IconButton } from "@chakra-ui/react";
 import { HiChevronLeft } from "react-icons/hi";
 
 type ContentHeaderProps = {
     children: React.ReactNode;
+    showBackButton?: boolean
 }
 
 
-const ContentHeader:React.FC<ContentHeaderProps> = ({children}: ContentHeaderProps) => {
+const ContentHeader:React.FC<ContentHeaderProps> = ({children, showBackButton}: ContentHeaderProps) => {
+    
+    const redirectToProjectPage = () => {
+        window.location.href = "/projects"
+    }
+
+    const renderBackButton = ():JSX.Element | null => {
+        
+        const backButton: JSX.Element = <IconButton size="xl" backgroundColor="#242424" onClick={redirectToProjectPage}><HiChevronLeft /></IconButton>
+        
+        return showBackButton ?  backButton : null;
+    }
+    
     return(
         <div className="content-header--main">
             <div className="flex items-start">
-                <IconButton size="xl" backgroundColor="#242424">
-                    <HiChevronLeft />
-                </IconButton>
+                {renderBackButton()}
                 {children}
             </div>
             

--- a/louis_venhoff_portfolio/src/pages/project/project.tsx
+++ b/louis_venhoff_portfolio/src/pages/project/project.tsx
@@ -60,7 +60,7 @@ const Project:React.FC= () => {
     return(
         <>
             <div className="project-main">
-                <ContentHeader>
+                <ContentHeader showBackButton={true}>
                     <div className="flex flex-col">
                         {currentDoc?.name}
                         <div className="flex gap-2">

--- a/louis_venhoff_portfolio/src/pages/project/project.tsx
+++ b/louis_venhoff_portfolio/src/pages/project/project.tsx
@@ -1,4 +1,4 @@
-import React, { JSX, useEffect, useState } from "react";
+import React, { JSX, useEffect, useRef, useState } from "react";
 import "../../styles/pages/project/project.css";
 import MarkdownElement from "../../components/markdownElement/markdownElement";
 import testMarkdown from "../../assets/test.md?raw";
@@ -15,6 +15,8 @@ const Project:React.FC= () => {
     const [currentDoc, setCurrentDoc] = useState<Doc>();
 
     const [markdown, setMarkdown] = useState<string>();
+
+    const tagsDiv = useRef<HTMLDivElement>(null);
 
     const docLoader = useDocument();
 
@@ -50,12 +52,28 @@ const Project:React.FC= () => {
         setMarkdown(markdownText);
     }
 
+    const calculateTagsDivSize = (badges: JSX.Element[]) => {
+        
+        let divSize:number = 0;
+
+        badges.forEach((element: JSX.Element) => {
+            divSize += 50;
+        });
+
+        tagsDiv.current!.style.width = `${divSize}px`;
+    }
+
     const renderTags = ():JSX.Element[] => {
         if(!currentDoc) return [];
 
-        return currentDoc.tags.map((tag, index) => 
-            <Badge key={index} maxW="sm" backgroundColor="#000000" color="teal">{tag}</Badge>
-        );
+        let tagBadges:JSX.Element[] = currentDoc.tags.map((tag, index) => {
+            return <Badge key={index} maxW="sm" backgroundColor="#000000" color="teal">{tag}</Badge>
+        });
+
+        calculateTagsDivSize(tagBadges);
+
+        return tagBadges;
+
     }
     
     return(
@@ -64,7 +82,7 @@ const Project:React.FC= () => {
                 <ContentHeader showBackButton={true}>
                     <div className="flex flex-col">
                         {currentDoc?.name}
-                        <div className="project-header--tags">
+                        <div ref={tagsDiv} className="project-header--tags">
                             <motion.div animate={{x: ["0%", "-50%"]}} transition={{repeat: Infinity, duration: 30, ease: "linear"}} className="flex gap-2">
                                 {renderTags()}
                                 {renderTags()}

--- a/louis_venhoff_portfolio/src/pages/project/project.tsx
+++ b/louis_venhoff_portfolio/src/pages/project/project.tsx
@@ -7,6 +7,7 @@ import Doc from "../../classes/doc";
 import { useParams } from "react-router-dom";
 import ContentHeader from "../../components/contentHeader/contentHeader";
 import { Badge } from "@chakra-ui/react";
+import * as motion from "motion/react-client";
 
 
 const Project:React.FC= () => { 
@@ -52,8 +53,8 @@ const Project:React.FC= () => {
     const renderTags = ():JSX.Element[] => {
         if(!currentDoc) return [];
 
-        return currentDoc.tags.map((tag, _) => 
-            <Badge maxW="sm" backgroundColor="#000000" color="teal">{tag}</Badge>
+        return currentDoc.tags.map((tag, index) => 
+            <Badge key={index} maxW="sm" backgroundColor="#000000" color="teal">{tag}</Badge>
         );
     }
     
@@ -63,12 +64,15 @@ const Project:React.FC= () => {
                 <ContentHeader showBackButton={true}>
                     <div className="flex flex-col">
                         {currentDoc?.name}
-                        <div className="flex gap-2">
-                            {renderTags()}
+                        <div className="project-header--tags">
+                            <motion.div animate={{x: ["0%", "-50%"]}} transition={{repeat: Infinity, duration: 30, ease: "linear"}} className="flex gap-2">
+                                {renderTags()}
+                                {renderTags()}
+                            </motion.div>
                         </div>
                     </div>
                 </ContentHeader>
-                <div className="project-main--markdown-viewer">
+                <div className="project--markdown-viewer">
                     <MarkdownElement markdown={markdown ?? testMarkdown} />
                 </div>
             </div>

--- a/louis_venhoff_portfolio/src/pages/project/project.tsx
+++ b/louis_venhoff_portfolio/src/pages/project/project.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { JSX, useEffect, useState } from "react";
 import "../../styles/pages/project/project.css";
 import MarkdownElement from "../../components/markdownElement/markdownElement";
 import testMarkdown from "../../assets/test.md?raw";

--- a/louis_venhoff_portfolio/src/pages/project/project.tsx
+++ b/louis_venhoff_portfolio/src/pages/project/project.tsx
@@ -6,6 +6,7 @@ import useDocument from "../../hooks/useDocument";
 import Doc from "../../classes/doc";
 import { useParams } from "react-router-dom";
 import ContentHeader from "../../components/contentHeader/contentHeader";
+import { Badge } from "@chakra-ui/react";
 
 
 const Project:React.FC= () => { 
@@ -47,12 +48,26 @@ const Project:React.FC= () => {
 
         setMarkdown(markdownText);
     }
+
+    const renderTags = ():JSX.Element[] => {
+        
+        if(!currentDoc) return [];
+        return currentDoc.tags.map((tag, _) => 
+            <Badge maxW="sm" backgroundColor="#000000" color="teal">{tag}</Badge>
+        );
+
+    }
     
     return(
         <>
             <div className="project-main">
                 <ContentHeader>
-                    {currentDoc?.name}
+                    <div className="flex flex-col">
+                        {currentDoc?.name}
+                        <div className="flex gap-2">
+                            {renderTags()}
+                        </div>
+                    </div>
                 </ContentHeader>
                 <div className="project-main--markdown-viewer">
                     <MarkdownElement markdown={markdown ?? testMarkdown} />

--- a/louis_venhoff_portfolio/src/pages/project/project.tsx
+++ b/louis_venhoff_portfolio/src/pages/project/project.tsx
@@ -50,12 +50,11 @@ const Project:React.FC= () => {
     }
 
     const renderTags = ():JSX.Element[] => {
-        
         if(!currentDoc) return [];
+
         return currentDoc.tags.map((tag, _) => 
             <Badge maxW="sm" backgroundColor="#000000" color="teal">{tag}</Badge>
         );
-
     }
     
     return(

--- a/louis_venhoff_portfolio/src/pages/project/project.tsx
+++ b/louis_venhoff_portfolio/src/pages/project/project.tsx
@@ -8,7 +8,7 @@ import { useParams } from "react-router-dom";
 import ContentHeader from "../../components/contentHeader/contentHeader";
 import { Badge } from "@chakra-ui/react";
 import * as motion from "motion/react-client";
-
+import { useAnimation } from "motion/react";
 
 const Project:React.FC= () => { 
     
@@ -21,6 +21,8 @@ const Project:React.FC= () => {
     const docLoader = useDocument();
 
     const {id} = useParams();
+
+    const animationController = useAnimation();
     
     useEffect(() => {
         loadDoc();
@@ -28,6 +30,7 @@ const Project:React.FC= () => {
 
     useEffect(() => {
         updateMarkdown();
+        setupAnimation((currentDoc?.tags.length ?? 0) > 9);
     }, [currentDoc]);
 
     const loadDoc = async () => {
@@ -75,6 +78,15 @@ const Project:React.FC= () => {
         return tagBadges;
 
     }
+
+    const setupAnimation = (enabled: boolean) => {
+        if(enabled){
+            animationController.start({x: ["0%", "-50%"]});
+        }
+        else{
+            animationController.start({x: 0});
+        }
+    }
     
     return(
         <>
@@ -83,7 +95,7 @@ const Project:React.FC= () => {
                     <div className="flex flex-col">
                         {currentDoc?.name}
                         <div ref={tagsDiv} className="project-header--tags">
-                            <motion.div animate={{x: ["0%", "-50%"]}} transition={{repeat: Infinity, duration: 30, ease: "linear"}} className="flex gap-2">
+                            <motion.div animate={animationController} transition={{repeat: Infinity, duration: 30, ease: "linear"}} className="flex gap-2">
                                 {renderTags()}
                                 {renderTags()}
                             </motion.div>

--- a/louis_venhoff_portfolio/src/styles/pages/project/project.css
+++ b/louis_venhoff_portfolio/src/styles/pages/project/project.css
@@ -15,7 +15,15 @@
     font-family: monospace;
 }
 
-.project-main--markdown-viewer{
+.project-header--tags{
+    display: flex;
+    gap: 10px;
+    width: 500px;
+    overflow: hidden;
+}
+
+
+.project--markdown-viewer{
     align-self: center;
     height: auto;
     width: 80%;


### PR DESCRIPTION
Improvements of the projects page header:

- Add back Button to get to the projects index page
- Show tags under the Project heading
- Animate tags like an Live ticker when there are more tags than 5 tags